### PR TITLE
Fix/issue 9 transfer payee resolution

### DIFF
--- a/src/tools/create-transaction.ts
+++ b/src/tools/create-transaction.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { getYnabClient } from "../ynab/client.js";
 import { resolveBudgetId } from "../ynab/types.js";
+import { resolveTransferPayee } from "../ynab/payee-resolver.js";
 import { formatError } from "../utils/errors.js";
 import { formatToolResponse } from "../utils/response-formatter.js";
 import { milliunitsToDisplay } from "../utils/milliunit.js";
@@ -69,12 +70,31 @@ export function registerCreateTransaction(server: McpServer): void {
         const ynab = getYnabClient();
         const id = resolveBudgetId(budget_id);
 
+        // Smart transfer payee resolution: if payee_name looks like an account name
+        // and no explicit payee_id was supplied, try to resolve to a transfer payee_id.
+        let resolvedPayeeName = payee_name ?? undefined;
+        let resolvedPayeeId = payee_id ?? undefined;
+
+        if (payee_name && !payee_id) {
+          const transferMatch = await resolveTransferPayee(ynab, id, payee_name);
+          if (transferMatch && "error" in transferMatch) {
+            return formatToolResponse(
+              `## Error: Ambiguous Payee\n\n${transferMatch.error}\n\nMatching transfer accounts:\n${transferMatch.matches.map((m) => `- ${m}`).join("\n")}`,
+              { error: transferMatch.error, matches: transferMatch.matches },
+            );
+          }
+          if (transferMatch) {
+            resolvedPayeeId = transferMatch.payee_id;
+            resolvedPayeeName = undefined; // payee_id takes precedence
+          }
+        }
+
         const transaction: Record<string, unknown> = {
           account_id,
           date,
           amount,
-          payee_name: payee_name ?? undefined,
-          payee_id: payee_id ?? undefined,
+          payee_name: resolvedPayeeName,
+          payee_id: resolvedPayeeId,
           category_id: category_id ?? undefined,
           memo: memo ?? undefined,
           cleared: cleared ?? "uncleared",

--- a/src/tools/create-transaction.ts
+++ b/src/tools/create-transaction.ts
@@ -24,7 +24,9 @@ export function registerCreateTransaction(server: McpServer): void {
       payee_name: z
         .string()
         .optional()
-        .describe("Payee name. YNAB will match to existing payees."),
+        .describe(
+          "Payee name. If this matches a YNAB account name (e.g. \"Schwab Checking\" or \"Transfer : Schwab Checking\"), it is automatically resolved to the correct transfer payee ID — use this for credit card payments and account transfers. For regular payees, YNAB matches by name as usual.",
+        ),
       payee_id: z.string().optional().describe("Existing payee ID"),
       category_id: z
         .string()
@@ -78,6 +80,7 @@ export function registerCreateTransaction(server: McpServer): void {
         if (payee_name && !payee_id) {
           const transferMatch = await resolveTransferPayee(ynab, id, payee_name);
           if (transferMatch && "error" in transferMatch) {
+            done("tool", "create_transaction aborted: ambiguous payee", {});
             return formatToolResponse(
               `## Error: Ambiguous Payee\n\n${transferMatch.error}\n\nMatching transfer accounts:\n${transferMatch.matches.map((m) => `- ${m}`).join("\n")}`,
               { error: transferMatch.error, matches: transferMatch.matches },

--- a/src/tools/preview-import.ts
+++ b/src/tools/preview-import.ts
@@ -7,6 +7,11 @@ import { formatToolResponse } from "../utils/response-formatter.js";
 import { milliunitsToDisplay } from "../utils/milliunit.js";
 import { logger, startTimer } from "../utils/logger.js";
 
+// Patterns that indicate an autopay / CC payment on a credit card statement.
+// Combined with an inflow-amount check (amount > 0) to avoid matching charge
+// entries from merchants whose names happen to contain these keywords.
+const CC_PAYMENT_PATTERNS = [/\bautopay\b/i, /\bauto[- ]?pmt\b/i, /\bauto[- ]?pay\b/i];
+
 const parsedTransactionSchema = z.object({
   date: z.string(),
   amount: z.number(),
@@ -101,11 +106,6 @@ export function registerPreviewImport(server: McpServer): void {
 
         const transferPayeeList = Array.from(historicalTransferPayees.values());
 
-        // Patterns that indicate an autopay / CC payment on a credit card statement.
-        // These are distinct enough to be credit-card-payment specific.
-        const CC_PAYMENT_PATTERNS =
-          [/\bautopay\b/i, /\bauto[- ]?pmt\b/i, /\bauto[- ]?pay\b/i];
-
         // Also fetch payees for name matching
         const payeesResp = await ynab.payees.getPayees(id);
         const ynabPayees = payeesResp.data.payees.filter((p) => !p.deleted);
@@ -114,13 +114,31 @@ export function registerPreviewImport(server: McpServer): void {
         const previews = filteredTransactions.map((txn) => {
           const normalizedPayee = txn.payee.toLowerCase().trim();
 
-          // Check if this looks like a CC payment / autopay entry
-          const isCCPayment = CC_PAYMENT_PATTERNS.some((p) =>
-            p.test(txn.payee),
-          );
+          // Check if this looks like a CC payment / autopay entry.
+          // Require amount > 0 (inflow) to avoid matching debit charges whose
+          // merchant name happens to contain "autopay" (e.g. "STATE FARM AUTOPAY").
+          const isCCPayment =
+            txn.amount > 0 &&
+            CC_PAYMENT_PATTERNS.some((p) => p.test(txn.payee));
 
-          if (isCCPayment && transferPayeeList.length > 0) {
-            // If history shows exactly one source account, we can resolve automatically.
+          if (isCCPayment) {
+            if (transferPayeeList.length === 0) {
+              // Autopay pattern detected but no prior transfer history on this account.
+              // Flag it so the agent knows to treat it as a transfer even without a
+              // resolved payee_id (e.g. first import, or prior payments used payee_name).
+              return {
+                ...txn,
+                is_transfer: true,
+                suggested_category_id: null,
+                suggested_category_name:
+                  "CC Payment (no prior transfer history — provide payee_id manually)",
+                category_match_confidence: "transfer-no-history",
+                matched_payee_id: null,
+                matched_payee_name: null,
+              };
+            }
+
+            // If history shows exactly one source account, resolve automatically.
             // If multiple accounts exist the agent must choose.
             const resolved =
               transferPayeeList.length === 1 ? transferPayeeList[0] : null;
@@ -184,6 +202,10 @@ export function registerPreviewImport(server: McpServer): void {
           0,
         );
 
+        // Exclude transfers from the categorized % — transfers are intentionally
+        // uncategorized (YNAB assigns CC payment categories automatically).
+        const regularCount = filteredTransactions.length - transfers;
+
         let md = `## Import Preview\n\n`;
         md += `- **Transactions:** ${filteredTransactions.length}\n`;
         if (filteredCount > 0) {
@@ -191,10 +213,10 @@ export function registerPreviewImport(server: McpServer): void {
         }
         md += `- **Total:** ${milliunitsToDisplay(totalAmount)}\n`;
         md += `- **Transfers (CC payments):** ${transfers}\n`;
-        const categorizedPercent = filteredTransactions.length > 0
-          ? Math.round((matched / filteredTransactions.length) * 100)
+        const categorizedPercent = regularCount > 0
+          ? Math.round((matched / regularCount) * 100)
           : 0;
-        md += `- **Categorized:** ${matched} (${categorizedPercent}%)\n`;
+        md += `- **Categorized:** ${matched} of ${regularCount} (${categorizedPercent}%)\n`;
         md += `- **Uncategorized:** ${unmatched}\n\n`;
 
         md += `| Date | Payee | Amount | Suggested Category | Confidence |\n`;

--- a/src/tools/preview-import.ts
+++ b/src/tools/preview-import.ts
@@ -61,16 +61,33 @@ export function registerPreviewImport(server: McpServer): void {
           );
         const history = historyResp.data.transactions;
 
-        // Build payee-to-category mapping from history
+        // Build payee-to-category mapping from history (regular transactions only)
         const payeeCategoryMap = new Map<
           string,
           { category_id: string; category_name: string; count: number }
         >();
 
+        // Build transfer payee map from history: keyed by payee_id so each unique
+        // source account is represented once. Used to detect CC payment transactions.
+        const historicalTransferPayees = new Map<
+          string,
+          { payee_id: string; payee_name: string }
+        >();
+
         for (const txn of history) {
-          if (!txn.payee_name || !txn.category_id) {
+          if (!txn.payee_name) continue;
+
+          if (txn.transfer_account_id && txn.payee_id) {
+            // Transfer (e.g. CC payment from Schwab Checking): track payee_id separately
+            historicalTransferPayees.set(txn.payee_id, {
+              payee_id: txn.payee_id,
+              payee_name: txn.payee_name,
+            });
             continue;
           }
+
+          if (!txn.category_id) continue;
+
           const normalized = txn.payee_name.toLowerCase().trim();
           const existing = payeeCategoryMap.get(normalized);
           if (!existing || txn.date > (existing as any).lastDate) {
@@ -82,6 +99,13 @@ export function registerPreviewImport(server: McpServer): void {
           }
         }
 
+        const transferPayeeList = Array.from(historicalTransferPayees.values());
+
+        // Patterns that indicate an autopay / CC payment on a credit card statement.
+        // These are distinct enough to be credit-card-payment specific.
+        const CC_PAYMENT_PATTERNS =
+          [/\bautopay\b/i, /\bauto[- ]?pmt\b/i, /\bauto[- ]?pay\b/i];
+
         // Also fetch payees for name matching
         const payeesResp = await ynab.payees.getPayees(id);
         const ynabPayees = payeesResp.data.payees.filter((p) => !p.deleted);
@@ -89,6 +113,30 @@ export function registerPreviewImport(server: McpServer): void {
         // Match each transaction
         const previews = filteredTransactions.map((txn) => {
           const normalizedPayee = txn.payee.toLowerCase().trim();
+
+          // Check if this looks like a CC payment / autopay entry
+          const isCCPayment = CC_PAYMENT_PATTERNS.some((p) =>
+            p.test(txn.payee),
+          );
+
+          if (isCCPayment && transferPayeeList.length > 0) {
+            // If history shows exactly one source account, we can resolve automatically.
+            // If multiple accounts exist the agent must choose.
+            const resolved =
+              transferPayeeList.length === 1 ? transferPayeeList[0] : null;
+            return {
+              ...txn,
+              is_transfer: true,
+              suggested_category_id: null,
+              suggested_category_name:
+                resolved
+                  ? `CC Payment → ${resolved.payee_name.replace(/^Transfer\s*:\s*/i, "")}`
+                  : "CC Payment (multiple source accounts — choose payee_id)",
+              category_match_confidence: resolved ? "transfer" : "transfer-ambiguous",
+              matched_payee_id: resolved?.payee_id ?? null,
+              matched_payee_name: resolved?.payee_name ?? null,
+            };
+          }
 
           // Try exact match first
           let suggestion = payeeCategoryMap.get(normalizedPayee);
@@ -115,6 +163,7 @@ export function registerPreviewImport(server: McpServer): void {
 
           return {
             ...txn,
+            is_transfer: false,
             suggested_category_id: suggestion?.category_id ?? null,
             suggested_category_name: suggestion?.category_name ?? null,
             category_match_confidence: suggestion
@@ -127,8 +176,9 @@ export function registerPreviewImport(server: McpServer): void {
           };
         });
 
-        const matched = previews.filter((p) => p.suggested_category_id).length;
-        const unmatched = previews.length - matched;
+        const transfers = previews.filter((p) => p.is_transfer).length;
+        const matched = previews.filter((p) => !p.is_transfer && p.suggested_category_id).length;
+        const unmatched = previews.length - transfers - matched;
         const totalAmount = filteredTransactions.reduce(
           (sum, t) => sum + t.amount,
           0,
@@ -140,6 +190,7 @@ export function registerPreviewImport(server: McpServer): void {
           md += `- **Filtered:** ${filteredCount} (before ${since_date})\n`;
         }
         md += `- **Total:** ${milliunitsToDisplay(totalAmount)}\n`;
+        md += `- **Transfers (CC payments):** ${transfers}\n`;
         const categorizedPercent = filteredTransactions.length > 0
           ? Math.round((matched / filteredTransactions.length) * 100)
           : 0;
@@ -152,12 +203,13 @@ export function registerPreviewImport(server: McpServer): void {
           md += `| ${p.date} | ${p.payee} | ${milliunitsToDisplay(p.amount)} | ${p.suggested_category_name ?? "_none_"} | ${p.category_match_confidence} |\n`;
         }
 
-        done("tool", "preview_import completed", { total: filteredTransactions.length, filtered: filteredCount, categorized: matched, uncategorized: unmatched });
+        done("tool", "preview_import completed", { total: filteredTransactions.length, filtered: filteredCount, transfers, categorized: matched, uncategorized: unmatched });
         return formatToolResponse(md, {
           account_id,
           total_count: filteredTransactions.length,
           filtered_count: filteredCount,
           total_amount: totalAmount,
+          transfer_count: transfers,
           categorized_count: matched,
           uncategorized_count: unmatched,
           previews,

--- a/src/tools/update-transaction.ts
+++ b/src/tools/update-transaction.ts
@@ -17,7 +17,12 @@ export function registerUpdateTransaction(server: McpServer): void {
       transaction_id: z.string().describe("ID of the transaction to update"),
       date: z.string().optional().describe("New date (YYYY-MM-DD)"),
       amount: z.number().optional().describe("New amount in milliunits"),
-      payee_name: z.string().optional().describe("New payee name"),
+      payee_name: z
+        .string()
+        .optional()
+        .describe(
+          "New payee name. If this matches a YNAB account name (e.g. \"Schwab Checking\" or \"Transfer : Schwab Checking\"), it is automatically resolved to the correct transfer payee ID. For regular payees, YNAB matches by name as usual.",
+        ),
       payee_id: z.string().optional().describe("New payee ID"),
       category_id: z.string().optional().describe("New category ID"),
       memo: z.string().optional().describe("New memo"),
@@ -58,6 +63,7 @@ export function registerUpdateTransaction(server: McpServer): void {
         if (payee_name !== undefined && payee_id === undefined) {
           const transferMatch = await resolveTransferPayee(ynab, id, payee_name);
           if (transferMatch && "error" in transferMatch) {
+            done("tool", "update_transaction aborted: ambiguous payee", {});
             return formatToolResponse(
               `## Error: Ambiguous Payee\n\n${transferMatch.error}\n\nMatching transfer accounts:\n${transferMatch.matches.map((m) => `- ${m}`).join("\n")}`,
               { error: transferMatch.error, matches: transferMatch.matches },

--- a/src/tools/update-transaction.ts
+++ b/src/tools/update-transaction.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { getYnabClient } from "../ynab/client.js";
 import { resolveBudgetId } from "../ynab/types.js";
+import { resolveTransferPayee } from "../ynab/payee-resolver.js";
 import { formatError } from "../utils/errors.js";
 import { formatToolResponse } from "../utils/response-formatter.js";
 import { milliunitsToDisplay } from "../utils/milliunit.js";
@@ -49,11 +50,30 @@ export function registerUpdateTransaction(server: McpServer): void {
         const ynab = getYnabClient();
         const id = resolveBudgetId(budget_id);
 
+        // Smart transfer payee resolution: if payee_name looks like an account name
+        // and no explicit payee_id was supplied, try to resolve to a transfer payee_id.
+        let resolvedPayeeName = payee_name;
+        let resolvedPayeeId = payee_id;
+
+        if (payee_name !== undefined && payee_id === undefined) {
+          const transferMatch = await resolveTransferPayee(ynab, id, payee_name);
+          if (transferMatch && "error" in transferMatch) {
+            return formatToolResponse(
+              `## Error: Ambiguous Payee\n\n${transferMatch.error}\n\nMatching transfer accounts:\n${transferMatch.matches.map((m) => `- ${m}`).join("\n")}`,
+              { error: transferMatch.error, matches: transferMatch.matches },
+            );
+          }
+          if (transferMatch) {
+            resolvedPayeeId = transferMatch.payee_id;
+            resolvedPayeeName = undefined; // payee_id takes precedence
+          }
+        }
+
         const updates: Record<string, unknown> = {};
         if (date !== undefined) updates.date = date;
         if (amount !== undefined) updates.amount = amount;
-        if (payee_name !== undefined) updates.payee_name = payee_name;
-        if (payee_id !== undefined) updates.payee_id = payee_id;
+        if (resolvedPayeeName !== undefined) updates.payee_name = resolvedPayeeName;
+        if (resolvedPayeeId !== undefined) updates.payee_id = resolvedPayeeId;
         if (category_id !== undefined) updates.category_id = category_id;
         if (memo !== undefined) updates.memo = memo;
         if (cleared !== undefined) updates.cleared = cleared;

--- a/src/ynab/payee-resolver.ts
+++ b/src/ynab/payee-resolver.ts
@@ -18,16 +18,27 @@ const CACHE_TTL_MS = 5 * 60 * 1000;
 const payeeCache = new Map<string, PayeeCache>();
 
 async function getPayees(api: ynab.API, budgetId: string): Promise<ynab.Payee[]> {
-  const cached = payeeCache.get(budgetId);
-  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
-    logger.debug("payee-resolver", "Using cached payees", { budgetId, count: cached.payees.length });
-    return cached.payees;
+  // Skip cache for "last-used" sentinel: YNAB resolves it to whichever budget was
+  // last active, which can change between calls. Caching under the sentinel would
+  // return stale payees from a different budget if the user switches budgets.
+  const isSentinel = budgetId === "last-used";
+
+  if (!isSentinel) {
+    const cached = payeeCache.get(budgetId);
+    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+      logger.debug("payee-resolver", "Using cached payees", { budgetId, count: cached.payees.length });
+      return cached.payees;
+    }
   }
 
   logger.info("payee-resolver", "Fetching payees from YNAB API", { budgetId });
   const response = await api.payees.getPayees(budgetId);
   const payees = response.data.payees;
-  payeeCache.set(budgetId, { payees, fetchedAt: Date.now() });
+
+  if (!isSentinel) {
+    payeeCache.set(budgetId, { payees, fetchedAt: Date.now() });
+  }
+
   return payees;
 }
 
@@ -64,7 +75,10 @@ export async function resolveTransferPayee(
   const payees = await getPayees(api, budgetId);
 
   // Transfer payees in YNAB are named "Transfer : <Account Name>"
-  const transferPayees = payees.filter((p) => p.transfer_account_id != null);
+  // Exclude deleted payees — YNAB returns them in the list but they're no longer valid.
+  const transferPayees = payees.filter(
+    (p) => p.transfer_account_id != null && !p.deleted,
+  );
 
   const normalizedInput = normalizeName(payeeName);
   const matches = transferPayees.filter(

--- a/src/ynab/payee-resolver.ts
+++ b/src/ynab/payee-resolver.ts
@@ -1,0 +1,99 @@
+/**
+ * Smart payee resolution for transfer transactions.
+ *
+ * When a user provides an account name as the payee (e.g. "Schwab Checking"),
+ * YNAB creates a generic inflow instead of a proper transfer. This module
+ * detects that pattern and resolves the correct transfer payee_id automatically.
+ */
+import type * as ynab from "ynab";
+import { logger } from "../utils/logger.js";
+
+interface PayeeCache {
+  payees: ynab.Payee[];
+  fetchedAt: number;
+}
+
+// Cache per budget, TTL = 5 minutes
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const payeeCache = new Map<string, PayeeCache>();
+
+async function getPayees(api: ynab.API, budgetId: string): Promise<ynab.Payee[]> {
+  const cached = payeeCache.get(budgetId);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    logger.debug("payee-resolver", "Using cached payees", { budgetId, count: cached.payees.length });
+    return cached.payees;
+  }
+
+  logger.info("payee-resolver", "Fetching payees from YNAB API", { budgetId });
+  const response = await api.payees.getPayees(budgetId);
+  const payees = response.data.payees;
+  payeeCache.set(budgetId, { payees, fetchedAt: Date.now() });
+  return payees;
+}
+
+/**
+ * Normalize a name for matching: lowercase, trim, strip "Transfer : " prefix.
+ */
+function normalizeName(name: string): string {
+  return name.toLowerCase().trim().replace(/^transfer\s*:\s*/i, "");
+}
+
+export interface TransferPayeeMatch {
+  payee_id: string;
+  payee_name: string;
+}
+
+export interface TransferPayeeAmbiguous {
+  error: string;
+  matches: string[];
+}
+
+/**
+ * Attempt to resolve a payee name to a YNAB transfer payee ID.
+ *
+ * Returns:
+ *   - TransferPayeeMatch if exactly one transfer payee matches the name
+ *   - TransferPayeeAmbiguous if multiple payees match
+ *   - null if no transfer payee matches (use payee_name as-is)
+ */
+export async function resolveTransferPayee(
+  api: ynab.API,
+  budgetId: string,
+  payeeName: string,
+): Promise<TransferPayeeMatch | TransferPayeeAmbiguous | null> {
+  const payees = await getPayees(api, budgetId);
+
+  // Transfer payees in YNAB are named "Transfer : <Account Name>"
+  const transferPayees = payees.filter((p) => p.transfer_account_id != null);
+
+  const normalizedInput = normalizeName(payeeName);
+  const matches = transferPayees.filter(
+    (p) => normalizeName(p.name) === normalizedInput,
+  );
+
+  if (matches.length === 0) {
+    logger.debug("payee-resolver", "No transfer payee match found", { payeeName });
+    return null;
+  }
+
+  if (matches.length > 1) {
+    logger.warn("payee-resolver", "Ambiguous transfer payee match", { payeeName, matches: matches.map((m) => m.name) });
+    return {
+      error: `Ambiguous payee "${payeeName}" matches multiple transfer accounts. Please use payee_id directly.`,
+      matches: matches.map((m) => m.name),
+    };
+  }
+
+  const match = matches[0];
+  logger.info("payee-resolver", "Resolved transfer payee", { payeeName, resolvedId: match.id, resolvedName: match.name });
+  return { payee_id: match.id, payee_name: match.name };
+}
+
+/** Clear cached payees for a budget (e.g. after account changes). */
+export function clearPayeeCache(budgetId?: string): void {
+  if (budgetId) {
+    payeeCache.delete(budgetId);
+  } else {
+    payeeCache.clear();
+  }
+}


### PR DESCRIPTION
## Fix: CC payments create proper YNAB transfers instead of generic inflows

Closes #9

### Problem

Two related failure modes when working with credit card transactions:

1. **`create_transaction` / `update_transaction`** — passing an account name as `payee_name` (e.g. `"Schwab Checking"`) caused YNAB to create a generic inflow with random category assignment instead of a proper account transfer. The fix requires supplying the internal transfer `payee_id`, which wasn't surfaced anywhere.

2. **`preview_import`** — autopay/CC payment entries on a bank statement (e.g. `"AUTOPAY 000000000052258RAUTOPAY AUTO-PMT"`) were not recognised as transfers. The preview matched them to a generic payee, so agents importing them created inflows rather than the correct transfer against the source checking account.

### Changes

**New: `src/ynab/payee-resolver.ts`**
- Fetches YNAB payees and matches an account name (either bare `"Schwab Checking"` or `"Transfer : Schwab Checking"`) to its transfer `payee_id`
- 5-minute in-memory cache per explicit budget ID (sentinel `"last-used"` is never cached to avoid cross-budget poisoning)
- Filters deleted payees from candidates
- Returns a clear error when the name is ambiguous (multiple accounts match)

**`create_transaction` + `update_transaction`**
- When `payee_name` is supplied without a `payee_id`, the resolver runs automatically before the YNAB API call
- On a successful match the transfer `payee_id` is injected and `payee_name` cleared (they are mutually exclusive in YNAB)
- `payee_name` schema description updated to document the auto-resolution behaviour

**`preview_import`**
- Account history is now scanned for prior transfer transactions (previously skipped because transfers have no `category_id`), building a map of historical transfer payees per source account
- Autopay patterns (`AUTOPAY`, `AUTO-PMT`, `AUTO-PAY`) combined with an inflow-amount guard (`amount > 0`) detect CC payment entries without false-positiving on debit charges from merchants with "autopay" in their name
- Detected payments are tagged `is_transfer: true` with `matched_payee_id` pre-filled from history when unambiguous; `transfer-ambiguous` when multiple source accounts exist; `transfer-no-history` on first import so agents know to supply `payee_id` manually
- Categorized % denominator now excludes transfers (which are intentionally uncategorized)

### Test plan

- [ ] `create_transaction` with `payee_name: "Schwab Checking"` → YNAB shows a proper transfer, not a generic inflow
- [ ] `create_transaction` with `payee_name: "Transfer : Schwab Checking"` → same result
- [ ] `create_transaction` with explicit `payee_id` → resolver skipped, behaviour unchanged
- [ ] `create_transaction` with a non-account payee name → normal YNAB name matching, no change
- [ ] `preview_import` on a CC statement with prior payment history → autopay row shows `is_transfer: true`, `matched_payee_id` populated, correct source account name in suggested category
- [ ] `preview_import` on a CC statement with no prior payment history → autopay row shows `transfer-no-history` confidence, `is_transfer: true`, `matched_payee_id: null`
- [ ] `preview_import` with a debit charge containing "autopay" in the name (e.g. insurance) → NOT flagged as transfer
- [ ] `preview_import` categorized % reflects only regular (non-transfer) transactions
